### PR TITLE
Delete Hiragana Validation

### DIFF
--- a/app/assets/javascripts/home.coffee
+++ b/app/assets/javascripts/home.coffee
@@ -2,10 +2,11 @@
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
+'''
 input = undefined
 input = []
 document.addEventListener 'DOMContentLoaded', (->
-  document.getElementById('table_name_field_name').addEventListener 'keyup', (e) ->
+  document.getElementById('message').addEventListener 'keyup', (e) ->
     tmp = undefined
     tmp = []
     @value.split('').forEach (item, i) ->
@@ -19,10 +20,11 @@ document.addEventListener 'DOMContentLoaded', (->
     return
   return
 ), false
+'''
 
 $(document).on 'click touchend', (e) ->
   $('#send').click ->
-    $('input#table_name_field_name').val("")
+    $('input#message').val("")
     alert ("メッセージを放流しました。")
     false
   return


### PR DESCRIPTION
・ひらがなのみの入力制限は挙動がおかしいため削除しました。
　別の方法で実装してみます。
・メッセージを放流したときに、テキストボックスのテキストをクリアするようにしました。