### PR TITLE
今まで取得したメッセージ一覧表示

### DIFF
--- a/app/assets/javascripts/home.coffee
+++ b/app/assets/javascripts/home.coffee
@@ -18,11 +18,25 @@ $ ->
     # 書き込みボタンをクリックした時、表示・非表示切り替え
     $('.write-icon img.write-icon').click ->
         if $('.message-wrap .textbox').css('visibility') == 'hidden'
+            if $('.all-message').css('display') == 'block'
+                $('.all-message').fadeOut();
             $('.message-wrap .textbox, input#send').css('visibility', 'visible')
         else
             $('.message-wrap .textbox, input#send').css('visibility', 'hidden')
             $("#message").css("box-shadow","");
             $(".error").css('visibility', 'hidden');
+        return
+
+    # かばんボタンをクリックした時、表示・非表示切り替え
+    $('.bag-icon img.bag-icon').click ->
+        if $('.all-message').css('display') == 'none'
+            if $('.message-wrap .textbox').css('visibility') == 'visible'
+                $('.message-wrap .textbox, input#send').css('visibility', 'hidden')
+                $("#message").css("box-shadow","");
+                $(".error").css('visibility', 'hidden');
+            $('.all-message').fadeIn();
+        else
+            $('.all-message').fadeOut();
         return
 
     # 未読アイコン(赤)をクリックした時
@@ -87,4 +101,4 @@ $(document).on 'click touchend', (e) ->
         else
             window.location = $(this).find('a').attr('href')
         false
-return
+    return

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -190,6 +190,10 @@ header{
 }
 
 /* メインページ */
+.contents-wrap{
+    position: relative;
+    z-index: 1;
+}
 .message-wrap{
     color: #fff;
     font-family: Hiragino Sans;
@@ -310,6 +314,75 @@ header{
 .post_all .message_item{
     border-bottom: 1px solid gray;
     padding-bottom: 20px;
+}
+
+// 受け取ったメッセージ一覧
+.all-message{
+    display: none;
+    width: 650px;
+    padding: 30px;
+    background: rgba(94,145,205,0.1);
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: #555;
+    overflow: scroll;
+    max-height: 50vh;
+    z-index: 2;
+    border-radius: 4px;
+}
+.all-message div.message{
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    border-bottom: 1px solid #aaa;
+    padding: 15px;
+}
+.all-message .message p.date{
+    width: 90%;
+    margin: 0;
+    font-size: 14px;
+}
+.all-message .message a{
+    display: block;
+    width: 5%;
+    margin-left: 5%;
+    text-decoration: none;
+    color: #D45D87;
+    font-family: 'Hiragino Sans';
+    font-weight: 700;
+    transition: .4s;
+}
+.all-message .message a:hover{
+    opacity: 0.8;
+    text-shadow: 1px 1px 2px rgba(50, 50, 150, 0.7);
+}
+.all-message .message p.message{
+    width: 100%;
+    text-align: left;
+    margin: 5px 0px 0px 0px;
+}
+
+@media screen and (max-width: 1100px) {
+    .all-message{
+        width: 550px;
+        max-height: 30vh;
+        top: 30%;
+    }
+}
+
+// スマホ向け
+@media screen and (max-width: 767px) {
+    .all-message{
+        width: 90vw;
+        padding: 15px;
+        overflow: scroll;
+        max-height: 30vh;
+        top: 30%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+    }
 }
 
 // 未読アイコン
@@ -446,10 +519,6 @@ input[type=number]::-webkit-outer-spin-button {
 }
 .icon-wrap .write-icon img:hover, .icon-wrap .bag-icon img:hover {
     filter: invert(80%);
-}
-
-img.bag-icon{
-    display: none;
 }
 
 @media screen and (max-width: 767px) {

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -14,8 +14,11 @@ class HomeController < ApplicationController
       else
           @loading = false
       end
-
       respond_to do |format|
+          # ユーザごとに保存されているメッセージを取得
+          @message_all = Receive.where(u_id: current_user.id)
+          @message = @message_all.map{|post| Post.find(post.mes_id)}
+
           format.html {
               @user = current_user.id
           } # html形式でアクセスがあった場合
@@ -55,6 +58,12 @@ class HomeController < ApplicationController
     @message.update(read_flag: true, dst_id: current_user.id)   # 開いたら既読に
     @receive = Receive.new(u_id: current_user.id, mes_id: @message.id)
     @receive.save
+  end
+
+  def destroy
+      @message = Receive.find_by(mes_id: params[:id])
+      @message.destroy
+      redirect_to "/home/main"
   end
 
 end

--- a/app/views/home/howto.html.erb
+++ b/app/views/home/howto.html.erb
@@ -29,7 +29,7 @@
     </div>
 
     <div class="back">
-        <%= link_to "もどる", "/home/main", data: {"turbolinks" => false} %>
+        <%= link_to "もどる", :back, data: {"turbolinks" => false} %>
     </div>
 </div>
 <div class="back-img" style="height: 100px; margin: 60px 0px;"></div>

--- a/app/views/home/main.html.erb
+++ b/app/views/home/main.html.erb
@@ -6,6 +6,18 @@
     <div class="animation"></div>
 </div>
 <% end %>
+
+<!-- 今まで受け取ったメッセージ -->
+<div class="all-message">
+    <% @message.each do |post| %>
+        <div class="message">
+            <p class="date"><%= post.created_at.strftime("%Y %m %d") %></p>
+            <%= link_to "×", "/home/receives/#{post.id}", method: :delete, data: {"turbolinks" => false} %>
+            <p class="message"><%= post.message %></p>
+        </div>
+    <% end %>
+</div>
+
 <div class="contents-wrap">
     <!-- メッセージの入力 -->
     <div class="message-wrap">
@@ -39,10 +51,11 @@
         <%= image_tag("new.png", :class => "unread-reply-icon") %>
         <%= image_tag("new.png", :class => "unread-icon") %>
     </div>
-
-    <!-- グレーアウト -->
-    <div id="overlay"></div>
 </div>
+
+<!-- グレーアウト -->
+<div id="overlay"></div>
+
 <div class="back-img">
     <%= image_tag("neko.png", :id => "cat") %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get 'home/main'
   post "home/main" => "home#create"
   post "home/message/:id" => "home#reply"
+  delete "home/receives/:id" => "home#destroy"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root "home#top"
   devise_for :users, controllers: {


### PR DESCRIPTION
＊今まで取得したメッセージの一覧を表示できるようになりました。
・ページにあるかばんのアイコンをクリックすると、今まで取得したメッセージが閲覧できます。
・×ボタンを押すことで削除が可能です。

ーーー軽微な修正ーーー
・はうとぅページのもどるボタンをクリックした際、遷移元のページにかかわらずメインページに遷移してしまう問題を修正しました。