### PR TITLE
メッセージにリンクを追加(非表示)

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -388,6 +388,11 @@ header{
     opacity: 0.8;
     text-shadow: 1px 1px 2px rgba(50, 50, 150, 0.7);
 }
+
+.all-message .message a#message_link{
+    display: none;
+}
+
 .all-message .message p.message{
     width: 100%;
     text-align: left;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -53,6 +53,9 @@ class HomeController < ApplicationController
 
   # メッセージ詳細表示
   def message
+      if request.referer.nil?
+          redirect_to "/home/main"
+      end
       @message = Post.find(params[:id])
       @message.update(read_flag: true, dst_id: current_user.id)   # 開いたら既読に
       @receive = Receive.new(u_id: current_user.id, mes_id: @message.id)

--- a/app/views/home/main.html.erb
+++ b/app/views/home/main.html.erb
@@ -5,6 +5,8 @@
             <p class="date"><%= post.created_at.strftime("%Y %m %d") %></p>
             <%= link_to "×", "/home/receives/#{post.id}", method: :delete, data: {"turbolinks" => false} %>
             <p class="message"><%= post.message %></p>
+            <%= link_to post.message, "/home/message/#{post.id}", :id => "message_link"%>
+
         </div>
     <% end %>
 </div>


### PR DESCRIPTION
届いたメッセージの一覧にリンクを追加してメッセージのページに遷移できるようになる(現在非表示)
メッセージのURLを直打ちした時にmainページにリダイレクトすることでメッセージが見えてしまうのを防ぐ