### PR TITLE
連続投稿を防ぐ・返信を1回のみにする

### DIFF
--- a/app/assets/javascripts/home.coffee
+++ b/app/assets/javascripts/home.coffee
@@ -17,6 +17,15 @@ $(window).on 'load', ->
         return
 
 $ ->
+    # 連続で投稿できないようにする
+    form = $('#message_form')
+    form.submit (event) ->
+        $(':input[type="image"]').prop('disabled', true);   # 投稿ボタンを無効化
+        # 投稿中メッセージ
+        # message = $('<div class="please-wait">Please Wait...</div>')
+        # form.append message
+        return
+
     messageid = ''  # 返信できたメッセージID格納用
 
     # 書き込みボタンをクリックした時、表示・非表示切り替え
@@ -82,9 +91,9 @@ $ ->
         return
 
     $ ->
-        # 定期的に返信が来ていないか10秒毎に確認
+        # 定期的に返信が来ていないか15秒毎に確認
         reply_receive()
-        setInterval reply_receive, 10000
+        setInterval reply_receive, 15000
         return
     return
 
@@ -97,6 +106,12 @@ $(document).on 'ajax:success', '#message_form', (e) ->
     $('.send-info p').html("めっせーじ を おくりました");
     $('.send-info').fadeIn();
     $('.send-info').delay(1500).fadeOut();
+    $(':input[type="image"]').prop('disabled', false);  # 投稿ボタンを有効化
+    if window.location.href.match(/\/home\/message\/[0-9]*/)    # メッセージ詳細画面にいる時はメインページへ
+        setTimeout (->
+            window.location.href = '/home/main/'
+            return
+            ), 1500
     return
 $(document).on 'ajax:error', '#message_form', (e) ->
     console.log e.detail[2]
@@ -104,6 +119,12 @@ $(document).on 'ajax:error', '#message_form', (e) ->
     $('.send-info p').html("めっせーじ を おくれませんでした");
     $('.send-info').fadeIn();
     $('.send-info').delay(1500).fadeOut();
+    $(':input[type="image"]').prop('disabled', false);  # 投稿ボタンを有効化
+    if window.location.href.match(/\/home\/message\/[0-9]*/)    # メッセージ詳細画面にいる時はメインページへ
+        setTimeout (->
+            window.location.href = '/home/main/'
+            return
+            ), 1500
     return
 
 # ボタン全体にリンクを効かせる

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -363,18 +363,25 @@ header{
 }
 
 .all-message div.message{
+    position: relative;
     display: flex;
     align-items: center;
     flex-wrap: wrap;
     border-bottom: 1px solid #aaa;
     padding: 15px;
+    transition: .4s;
+}
+div.message:hover {
+    transform: scale(1.05);
+    /* letter-spacing: 0.2em; */
+    /* font-size: 14px; */
 }
 .all-message .message p.date{
     width: 90%;
     margin: 0;
     font-size: 14px;
 }
-.all-message .message a{
+.all-message .message a#delete{
     display: block;
     width: 5%;
     margin-left: 5%;
@@ -383,14 +390,23 @@ header{
     font-family: 'Hiragino Sans';
     font-weight: 700;
     transition: .4s;
+    z-index: 2;
 }
-.all-message .message a:hover{
+.all-message .message a#delete:hover{
     opacity: 0.8;
-    text-shadow: 1px 1px 2px rgba(50, 50, 150, 0.7);
+    transform: scale(1.3);
 }
 
 .all-message .message a#message_link{
-    display: none;
+    position: absolute;
+    line-height: 1.4;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    text-indent: 200%;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .all-message .message p.message{
@@ -417,6 +433,11 @@ header{
         top: 30%;
         left: 50%;
         transform: translate(-50%, -50%);
+    }
+    div.message:hover {
+        transform: scale(1);
+        /* letter-spacing: 0.2em; */
+        /* font-size: 14px; */
     }
     .send-info{
         width: 90vw;
@@ -526,6 +547,11 @@ input[type=number]::-webkit-outer-spin-button {
 
 .message-view .icon-wrap{
     margin-top: 25px;
+}
+
+div.replyed p{
+    text-align: center;
+    color: #888;
 }
 
 .back{

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -46,6 +46,9 @@ class HomeController < ApplicationController
       else
           @reply = Post.new(message:params[:message], read_flag:"false", src_id: current_user.id, dst_id: @replyto.src_id, anc_id: @replyto.anc_id)
       end
+      # 返信したらフラグを立てる
+      @message_replyed = Receive.find_by(u_id: current_user.id, mes_id: @replyto.id)
+      @message_replyed.update(reply_flag: true)
       if !@reply.save
           render :new, notice: "Error"
       end
@@ -63,8 +66,10 @@ class HomeController < ApplicationController
           @receive.save
       end
       if @message.anc_id.present?
-          @message_history = Post.where(anc_id: @message.anc_id).or(Post.where(id: @message.anc_id))
+          @message_history = (Post.where(anc_id: @message.anc_id).or(Post.where(id: @message.anc_id))).order(created_at: "ASC")
       end
+      # 返信フラグがtrueのときは返信できない
+      @message_replyed = Receive.find_by(u_id: current_user.id, mes_id: @message.id)
   end
 
   def destroy

--- a/app/views/home/main.html.erb
+++ b/app/views/home/main.html.erb
@@ -3,9 +3,9 @@
     <% @message.each do |post| %>
         <div class="message">
             <p class="date"><%= post.created_at.strftime("%Y %m %d") %></p>
-            <%= link_to "×", "/home/receives/#{post.id}", method: :delete, data: {"turbolinks" => false} %>
+            <%= link_to "×", "/home/receives/#{post.id}", method: :delete, id: "delete", data: {"turbolinks" => false} %>
             <p class="message"><%= post.message %></p>
-            <%= link_to post.message, "/home/message/#{post.id}", :id => "message_link"%>
+            <%= link_to post.message, "/home/message/#{post.id}", :id => "message_link", data: {"turbolinks" => false}%>
 
         </div>
     <% end %>
@@ -68,19 +68,17 @@
 function hiraganacheck() {
     message = $("#message").val();
     var ng = ['ばか'];//禁止ワード
-   if(message.match(ng) !=null){
-         //$("#message").css("box-shadow", "0px 0px 10px red");
-         //$(".error").css('visibility', 'visible');
-         alert('ふてきせつな　もじが　ふくまれています');
-         return false;
-     }
-   if(message.match(/[^ぁ-ん０-９0-9ー〜！？!?、。「」^ \r　\n\ \s]+/ )){
+    if(message.match(ng) !=null){
+        //$("#message").css("box-shadow", "0px 0px 10px red");
+        //$(".error").css('visibility', 'visible');
+        alert('ふてきせつな　もじが　ふくまれています');
+        return false;
+    }
+    if(message.match(/[^ぁ-ん０-９0-9ー〜！？!?、。「」^ \r　\n\ \s]+/ )){
         $("#message").css("box-shadow", "0px 0px 10px red");
         $(".error").css('visibility', 'visible');
         return false;
-    }
-
-   else{
+    }else{
         $("#message").css("box-shadow","");
         $(".error").css('visibility', 'hidden');
         return true;

--- a/app/views/home/message.html.erb
+++ b/app/views/home/message.html.erb
@@ -19,22 +19,28 @@
             </div>
         <% end %>
     <% end %>
+    <% if @message_replyed.reply_flag == false %>
+        <!-- 返信していない時 -->
+        <div class="message-wrap">
+            <%= form_with model: @post, id: "message_form", onsubmit: "return hiraganacheck()" do |f| %>
 
-    <div class="message-wrap">
-        <%= form_with model: @post, id: "message_form", onsubmit: "return hiraganacheck()" do |f| %>
-
-            <%= f.text_area :message, :class => "textbox", :placeholder => "おへんじ かいてみる？", :onblur => "return hiraganacheck()" %>
-            <%= image_submit_tag("bottle_slh.png", id: "send") %>
-            <!-- 送信前に確認したい場合 -->
-            <!--<%= image_submit_tag("send.png", id: "send", data: { confirm: "めっせーじを おくりますか？"}) %>-->
-        <% end %>
-    </div>
-    <div class="icon-wrap">
-        <div class="write-icon">
-            <%= image_tag("pencil.png", :class => "write-icon") %>
+                <%= f.text_area :message, :class => "textbox", :placeholder => "おへんじ かいてみる？", :onblur => "return hiraganacheck()" %>
+                <%= image_submit_tag("bottle_slh.png", id: "send") %>
+                <!-- 送信前に確認したい場合 -->
+                <!--<%= image_submit_tag("send.png", id: "send", data: { confirm: "めっせーじを おくりますか？"}) %>-->
+            <% end %>
         </div>
-    </div>
-
+        <div class="icon-wrap">
+            <div class="write-icon">
+                <%= image_tag("pencil.png", :class => "write-icon") %>
+            </div>
+        </div>
+    <% else %>
+        <!-- 返信済みの時 -->
+        <div class="replyed">
+            <p>かこに　おへんじを　かきました</p>
+        </div>
+    <% end %>
     <div class="back">
         <%= link_to "もどる", '/home/main', data: {"turbolinks" => false} %>
     </div>


### PR DESCRIPTION
＊ボタンを連打した際、連続で投稿できてしまう問題を修正しました。
＊返信を1回のみに制限しました。
＊今までもらっためっせーじ一覧から、そのめっせーじの画面(返信画面)に飛べるようにしました。

ーーー細かい修正・詳細ーーー
・投稿ボタンをクリック後、サーバからレスポンスが返ってくるまでは投稿ボタンを無効化しました。
・返信を書いた際、メインページにリダイレクトされるようにしました。
・返信を書いたことのあるメッセージには、返信画面を表示しないようにしました。
・返信履歴の並び順を新しい順に変更しました。
・一部CSSを変更しました。